### PR TITLE
Change access level of classes to public

### DIFF
--- a/sdk-android/src/com/tune/crosspromo/TuneAdUtils.java
+++ b/sdk-android/src/com/tune/crosspromo/TuneAdUtils.java
@@ -15,7 +15,7 @@ import com.mobileapptracker.MATParameters;
 /**
  * Helper class for Tune Ads
  */
-class TuneAdUtils {
+public class TuneAdUtils {
     private static TuneAdUtils INSTANCE;
     
     static final String AD_ACTIVITY_KEY = "tune_ad_activity_active";

--- a/sdk-android/src/com/tune/crosspromo/TuneAdView.java
+++ b/sdk-android/src/com/tune/crosspromo/TuneAdView.java
@@ -7,7 +7,7 @@ import android.webkit.WebView;
 /**
  * Class that contains ad and metadata information from server
  */
-class TuneAdView {
+public class TuneAdView {
     public String placement;
     public TuneAdMetadata metadata;
     public String requestId;

--- a/sdk-android/src/com/tune/crosspromo/TuneCloseButton.java
+++ b/sdk-android/src/com/tune/crosspromo/TuneCloseButton.java
@@ -13,7 +13,7 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 
-class TuneCloseButton extends FrameLayout {
+public class TuneCloseButton extends FrameLayout {
     private ImageButton close;
 
     private TuneAdActivity adActivity;


### PR DESCRIPTION
When compiling MobilAppTrakerBindingAndriod solution in Xamarin, I was getting the following errors:

~/work/mat-tracking/xamarin-plugin/android/MobileAppTrackerBindingAndroid/MobileAppTrackerBindingAndroid/obj/Release/generated/src/Com.Tune.Crosspromo.TuneAdActivity.cs(38,38): Error CS0234: The type or namespace name `TuneAdView' does not exist in the namespace `Com.Tune.Crosspromo'. Are you missing an assembly reference? (CS0234) (MobileAppTrackerBindingAndroid)

~/work/mat-tracking/xamarin-plugin/android/MobileAppTrackerBindingAndroid/MobileAppTrackerBindingAndroid/obj/Release/generated/src/Com.Tune.Crosspromo.TuneAdActivity.cs(41,41): Error CS0234: The type or namespace name `TuneCloseButton' does not exist in the namespace `Com.Tune.Crosspromo'. Are you missing an assembly reference? (CS0234) (MobileAppTrackerBindingAndroid)

~/work/mat-tracking/xamarin-plugin/android/MobileAppTrackerBindingAndroid/MobileAppTrackerBindingAndroid/obj/Release/generated/src/Com.Tune.Crosspromo.TuneAdActivity.cs(41,41): Error CS0234: The type or namespace name `TuneAdUtils' does not exist in the namespace `Com.Tune.Crosspromo'. Are you missing an assembly reference? (CS0234) (MobileAppTrackerBindingAndroid)


I have found out that the missing classes did not have public access and that caused error in Xamarin. 

