### PR TITLE
Bug-fix: updated NS_ENUM declaration on TuneGender.

### DIFF
--- a/sdk-ios/MobileAppTracker.framework/Headers/Tune.h
+++ b/sdk-ios/MobileAppTracker.framework/Headers/Tune.h
@@ -297,11 +297,11 @@ typedef NS_ENUM(NSInteger, TuneErrorCode)
 #if !TARGET_OS_IOS
 
 /** @name Gender type constants */
-typedef NS_ENUM(NSInteger) {
+typedef NS_ENUM(NSInteger, TuneGender) {
     TuneGenderUnknown,
     TuneGenderMale,
     TuneGenderFemale
-} TuneGender;
+};
 
 #endif
 


### PR DESCRIPTION
Fixes an invalid macro definition; it's a mix between an old C-style enum + typedef and Apple's "modern objective-c" standard described here: https://developer.apple.com/library/ios/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html#//apple_ref/doc/uid/TP40014150-CH1-SW6 

Trying to build the original declaration in a Swift project resulted in the following error(s): 
![screen shot 2015-11-12 at 3 16 49 pm](https://cloud.githubusercontent.com/assets/7064929/11131678/732565fe-8951-11e5-87dc-54e9ac2dbbe0.png)
