### PR TITLE
Use system property to determine userAgent instead of WebView

### DIFF
--- a/sdk-android/src/com/mobileapptracker/MATParameters.java
+++ b/sdk-android/src/com/mobileapptracker/MATParameters.java
@@ -25,6 +25,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
@@ -80,9 +81,7 @@ public class MATParameters {
 
             new Thread(new GetGAID(context)).start();
             
-            // Execute Runnable on UI thread to set user agent
-            Handler handler = new Handler(Looper.getMainLooper());
-            handler.post(new GetUserAgent(mContext));
+            calculateUserAgent();
 
             // Get app package information
             String packageName = mContext.getPackageName();
@@ -190,6 +189,20 @@ public class MATParameters {
         }
     }
     
+    /**
+     * Determine the device's user agent and set the corresponding field.
+     */
+    private void calculateUserAgent() {
+        String userAgent = System.getProperty("http.agent", "");
+        if (TextUtils.isEmpty(userAgent)) {
+            // Execute Runnable on UI thread to set user agent
+            Handler handler = new Handler(Looper.getMainLooper());
+            handler.post(new GetUserAgent(mContext));
+        } else {
+            setUserAgent(userAgent);
+        }
+    }
+
     private class GetGAID implements Runnable {
         private final WeakReference<Context> weakContext;
         
@@ -800,7 +813,7 @@ public class MATParameters {
     public synchronized String getUserAgent() {
         return mUserAgent;
     }
-    private void setUserAgent(String userAgent) {
+    private synchronized void setUserAgent(String userAgent) {
         mUserAgent = userAgent;
     }
     

--- a/sdk-android/src/com/mobileapptracker/MobileAppTracker.java
+++ b/sdk-android/src/com/mobileapptracker/MobileAppTracker.java
@@ -737,7 +737,7 @@ public class MobileAppTracker {
     }
 
     /**
-     * Gets the device browser user agent
+     * Gets the device user agent
      * @return device user agent
      */
     public String getUserAgent() {


### PR DESCRIPTION
Problem:
———————
Using a WebView to determine the userAgent requires about 250ms on a
Nexus 5. Worse, this blocks the main thread!

At Uber, this causes startup performance problems in our Rider app.
We're going to have a meeting with John B on Thursday to discuss ways
we can address the performance problem. It would be cool if we could
engineer a solution before hand :)

Fix:
———————
Instead, lets use the “http.agent” system property when it is
available (should be available on >= 2.1).

This does not return the exact same user agent string. Instead of
returning the web browser's user agent we now get the android OS's user
agent. This is more appropriate. We aren't tracking mobile web apps. We
are tracking mobile android apps. Plus, I suspect you guys aren't using
the WebView userAgent to determine whether the user clicked a browser
add with the same userAgent, since the user's android browser's user
agent doesn't always match the WebView useragent.

Example user agent before change:
———————
Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48G)
AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0
Mobile Safari/537.36

Example user agent after change:
———————
Dalvik/2.1.0 (Linux; U; Android 5.1.1; Nexus 5 Build/LMY48G)

Testing:
———————
Executed 10 times on a Nexus 5 before and after change. Verified that
the average startup performance of the Uber Rider application improved
by over 200ms.